### PR TITLE
Enable port forwarding in example and fix IGD bug

### DIFF
--- a/examples/echo_service.rs
+++ b/examples/echo_service.rs
@@ -26,8 +26,9 @@ async fn main() -> Result<(), Error> {
 
     let qp2p = QuicP2p::with_config(
         Some(Config {
-            ip: Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            ip: None,
             port: Some(0),
+            forward_port: true,
             ..Default::default()
         }),
         &bootstrap_nodes,

--- a/examples/echo_service.rs
+++ b/examples/echo_service.rs
@@ -1,10 +1,7 @@
 use anyhow::{anyhow, bail, Error, Result};
 use bytes::Bytes;
 use qp2p::{Config, Message, QuicP2p};
-use std::{
-    env,
-    net::{IpAddr, Ipv4Addr},
-};
+use std::env;
 use tokio::io::AsyncBufReadExt;
 
 #[tokio::main]

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -176,7 +176,8 @@ impl IncomingMessages {
     }
 
     /// Returns the address of the peer who initiated the connection
-    #[must_use] pub fn remote_addr(&self) -> SocketAddr {
+    #[must_use]
+    pub fn remote_addr(&self) -> SocketAddr {
         *self.remover.remote_addr()
     }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -96,7 +96,7 @@ impl Endpoint {
     /// such an address cannot be reached and hence not useful.
     async fn public_addr(&self) -> Result<SocketAddr> {
         // Skip port forwarding
-        if self.local_addr.ip().is_loopback() || !self.local_addr.ip().is_unspecified() {
+        if self.local_addr.ip().is_loopback() {
             return Ok(self.local_addr);
         }
 
@@ -150,7 +150,9 @@ impl Endpoint {
             Err(e) => info!("Echo service timed out: {:?}", e),
         }
 
-       addr.map_or(Err(Error::NoEchoServiceResponse), |socket_addr| Ok(socket_addr))
+        addr.map_or(Err(Error::NoEchoServiceResponse), |socket_addr| {
+            Ok(socket_addr)
+        })
     }
 
     /// Connects to another peer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
+    unknown_crate_types
 )]
 #![deny(
     bad_style,


### PR DESCRIPTION
IGD bug description:
If the local IP address of the genesis node was passed then IGD was being skipped and the local address was being returned as the connection information.